### PR TITLE
Improve 'static_url' generation customization

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -28,11 +28,12 @@ def create_app(config_name):
 
     if app.config['SSL_REDIRECT']:
         from flask_talisman import Talisman
+        static = f"{app.config['PREFERRED_URL_SCHEME']}://{app.config['STATIC_SERVER_NAME']}"
         csp = {
             'default-src': '\'self\'',
-            'img-src': ['\'self\'', 'https://cdn.jsdelivr.net', 'data:'],
-            'script-src': ['\'self\'', 'https://cdn.jsdelivr.net'],
-            'style-src': ['\'self\'', 'https://cdn.jsdelivr.net']
+            'img-src': ['\'self\'', 'https://cdn.jsdelivr.net', static, 'data:'],
+            'script-src': ['\'self\'', 'https://cdn.jsdelivr.net', static],
+            'style-src': ['\'self\'', 'https://cdn.jsdelivr.net', static]
         }
         talisman = Talisman(app, content_security_policy=csp)
 

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -4,8 +4,8 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
         <title>{% block title %}{% endblock %} - DVC Tracker</title>
-        <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='bootstrap/5.1.3/bootstrap.min.css') }}">
-        <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='css/dvctracker-1.css') }}">
+        <link rel="stylesheet" type="text/css" href="{{ static_url('bootstrap/5.1.3/bootstrap.min.css') }}">
+        <link rel="stylesheet" type="text/css" href="{{ static_url('css/dvctracker-1.css') }}">
         {% block css %}{% endblock %}
     </head>
     <body>

--- a/app/templates/criteria/criteria_template.html
+++ b/app/templates/criteria/criteria_template.html
@@ -47,5 +47,5 @@
 {% endblock container %}
 {% block javascript %}
     {{ super() }}
-    <script src="{{ url_for('static', filename='js/dvctracker-criteria-1.js') }}"></script>
+    <script src="{{ static_url('js/dvctracker-criteria-1.js') }}"></script>
 {% endblock javascript %}

--- a/app/templates/specials/email_template.html
+++ b/app/templates/specials/email_template.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
     <title>{% if env_label %}({{ env_label }}) {% endif %}{% if title %}{{ title }} {% endif %}Specials - DVC Tracker</title>
     {% set css_filename = "css/dvctracker-specials-1.css" %}
-    <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename=css_filename) if request else css_filename }}">
+    <link rel="stylesheet" type="text/css" href="{{ static_url(css_filename) if request else css_filename }}">
   </head>
   <body>
     <table role="presentation" border="0" cellpadding="0" cellspacing="0" class="body">

--- a/app/templates/user/user_template.html
+++ b/app/templates/user/user_template.html
@@ -27,5 +27,5 @@
 {% block javascript %}
     {{ super() }}
     <script src="https://cdn.jsdelivr.net/npm/intl-tel-input@17.0.18/build/js/intlTelInput.min.js" integrity="sha256-B59tg1fQLJTf1b/7MvziVaCT8AmEOftoNAfBJqsAwBU=" crossorigin="anonymous"></script>
-    <script src="{{ url_for('static', filename='js/dvctracker-user-1.js') }}"></script>
+    <script src="{{ static_url('js/dvctracker-user-1.js') }}"></script>
 {% endblock javascript %}

--- a/config.py
+++ b/config.py
@@ -3,7 +3,9 @@ import os
 class Config:
     SECRET_KEY = os.getenv('SECRET_KEY')
     SEND_FILE_MAX_AGE_DEFAULT = int(os.getenv('SEND_FILE_MAX_AGE_DEFAULT', 31536000))
-    EMAIL_SERVER_NAME = os.getenv('EMAIL_SERVER_NAME')
+    ALWAYS_STATIC_SERVER = os.getenv('ALWAYS_STATIC_SERVER', 'True') == 'True'
+    STATIC_SERVER_NAME = os.getenv('STATIC_SERVER_NAME')
+    STATIC_DIRECTORY = os.getenv('STATIC_DIRECTORY')
     PREFERRED_URL_SCHEME = os.getenv('PREFERRED_URL_SCHEME', 'https')
     STATIC_DATA_PATH = os.getenv('STATIC_DATA_PATH', "static_data.toml")
     SQLALCHEMY_DATABASE_URI = os.getenv('DATABASE_URL')


### PR DESCRIPTION
This will allow greater control over how urls are created from 'static_url'. This includes the option to always generate a url that uses the static server (rather than only when not in a request context) and also adds the ability to specify a 'script_name' in the event the assets are in a subdirectory on the static server. This also adds the ability to include anchor links in the urls, which 'url_for' supports, and is needed for the svg asset.

*HOWEVER*, it is important to note that you cannot load svgs from an external server. So unfortunately for the time being, the svg asset will need to continue to be fetched from the app directly. This is because svgs don't currently support crossorigin. More info on that here: [https://oreillymedia.github.io/Using_SVG/extras/ch10-cors.html](https://oreillymedia.github.io/Using_SVG/extras/ch10-cors.html)

This shouldn't be too bad from a UX perspective because the svgs are only used on 'web only' views (since they aren't supported by email clients). So the server will already be up and running when they are requested and there won't be a noticeable delay in their loading. Once they are loaded they also have a very long cache duration, so they shouldn't need to be requested frequently.