### PR TITLE
Include messageID with push notification

### DIFF
--- a/app/notifications/send/emails.py
+++ b/app/notifications/send/emails.py
@@ -36,6 +36,9 @@ def send_email(subject, email_message, email_addresses, html_message=True):
     if not notification_response.success:
         notification_response.msg = f"{response.status_code} {response.reason}"
 
+    if notification_response.success:
+        notification_response.data = response.json().get("id")
+
     return notification_response
 
 @log_response("Mailgun", "Update Message Complete", True)

--- a/app/notifications/send/util.py
+++ b/app/notifications/send/util.py
@@ -1,9 +1,10 @@
 from functools import wraps
 
 class NotificationResponse:
-    def __init__(self, success=None, msg=None):
+    def __init__(self, success=None, msg=None, data=None):
         self.success = success
         self.msg = msg
+        self.data = data
 
 NotificationResponse.Success = NotificationResponse(True)
 NotificationResponse.Fail = NotificationResponse(False)


### PR DESCRIPTION
On the mobile app, it is possible to directly open an email if you have the messageID. So this commit adds the functionality to include an optional messageID in the push notification.