### PR TITLE
Make special_type optional

### DIFF
--- a/app/main/forms/forms.py
+++ b/app/main/forms/forms.py
@@ -34,7 +34,7 @@ from ...util import SpecialTypes, ContactTypes
 FieldTuple = namedtuple("FieldTuple", ["data"])
 
 class ImportantCriteriaForm(Form):
-    special_type = SelectField("Special Type", [InputRequired()], choices=[(SpecialTypes.PRECONFIRM, "Preconfirmed Reservation"), (SpecialTypes.DISC_POINTS, "Discounted Points")], coerce=SpecialTypes, default=SpecialTypes.PRECONFIRM)
+    special_type = SelectField("Special Type", [Optional()], choices=[(SpecialTypes.PRECONFIRM, "Preconfirmed Reservation"), (SpecialTypes.DISC_POINTS, "Discounted Points")], coerce=SpecialTypes, default=SpecialTypes.PRECONFIRM)
     check_in_date = DateField("Check In", [RequiredWhen(lambda field, form: form.special_type.data == SpecialTypes.PRECONFIRM and bool(form.check_out_date.data), message="This field is required when setting a Check Out date for a Preconfirmed Reservation.")])
     check_out_date = DateField("Check Out", [RequiredIf("check_in_date", message="This field is required when setting a Check In date.")])
     length_of_stay = IntegerField("Length of Stay (Nights - Minimum)", [Optional(), NumberRange(min=1, max=30, message="Must be between 1 and 30.")])


### PR DESCRIPTION
This commit makes 'special_type' from ImportantCriteriaForm an optional field. This was needed because validation was failing if all criteria were removed from the criteria view. This is because there is a 'min_entries' of 1 set on the FieldList. So when submitting the form with no entries, a blank one is created. But when validating this blank entry, the 'special_type' has no raw data and will fail validation. By making it optional, it doesn't matter if it doesn't include any raw data. And since there is a default value for the field, any code that relies on this always having a value, will still work as it will just be filled with the default.