### PR TITLE
Only show 'old_duration' when it is defined

### DIFF
--- a/app/templates/specials/preconfirmed_template.html
+++ b/app/templates/specials/preconfirmed_template.html
@@ -60,7 +60,7 @@
               {% if special.old_check_in is defined or special.old_check_out is defined %}
               <tr>
                 <td class="item-dates item-old-value">
-                  {{ special.old_check_in|datetimeformat|nullable if special.old_check_in is defined else special.check_in|datetimeformat|nullable }} - {{ special.old_check_out|datetimeformat|nullable if special.old_check_out is defined else special.check_out|datetimeformat|nullable }}<span>({{ special.old_duration|nullable }} {% if special.old_duration %}night{{'s' if special.old_duration > 1}}{% endif %})</span>
+                  {{ special.old_check_in|datetimeformat|nullable if special.old_check_in is defined else special.check_in|datetimeformat|nullable }} - {{ special.old_check_out|datetimeformat|nullable if special.old_check_out is defined else special.check_out|datetimeformat|nullable }}<span>{% if special.old_duration is defined %}({{ special.old_duration|nullable }} {% if special.old_duration %}night{{'s' if special.old_duration > 1}}{% endif %}){% endif %}</span>
                 </td>
               </tr>
               {% endif %}


### PR DESCRIPTION
If both the check-in and check-out dates change by the same amount, the duration is unchanged. This means there is no `old_duration` to show. This commit makes it so we don't try to show it when it isn't there (avoiding the `??` output).