### PR TITLE
Remove 'apt-get clean' from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.9-slim AS base
 
-RUN apt-get clean && apt-get -y update && \
+RUN apt-get -y update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     locales libpq-dev tmux
 


### PR DESCRIPTION
So I had this in the beginning of the set of commands...which means it wasn't actually cleaning all the stuff I was running after it. Plus I read that Debian automatically runs clean after doing an install, so I don't need to worry about it.