### PR TITLE
Add pages_release.yml to static branch

### DIFF
--- a/ghp_release.py
+++ b/ghp_release.py
@@ -2,6 +2,7 @@ from pathlib import Path
 import click, shutil, subprocess, time
 
 GHP_RESOURCES = [
+    ".github/workflows/pages_release.yml",
     "app/static",
     "README.md"
 ]


### PR DESCRIPTION
Without this, the pages workflow won't be triggered automatically when I run `ghp_release.py`.