### PR TITLE
Fix package-mode in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,6 @@ authors = [
     {name = "George Waters", email = "gwatersdev@gmail.com"},
 ]
 license = {text = "MIT"}
-package-mode = false
 requires-python = "<4.0,>=3.12"
 dependencies = [
     "flask<4.0.0,>=3.0.3",
@@ -28,6 +27,9 @@ dependencies = [
     "premailer @ git+https://github.com/dunkmann00/premailer.git@parsestyle-validate-option",
     "pynacl (>=1.5.0,<2.0.0)",
 ]
+
+[tool.poetry]
+package-mode = false
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
'package-mode' is supposed to go in the [tool.poetry] table. I incorrectly moved it into the [project] table. This moves it back.