### PR TITLE
Add dotenv flask extra for dev

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -631,6 +631,7 @@ blinker = ">=1.9"
 click = ">=8.1.3"
 itsdangerous = ">=2.2"
 Jinja2 = ">=3.1.2"
+python-dotenv = {version = "*", optional = true, markers = "extra == \"dotenv\""}
 Werkzeug = ">=3.1"
 
 [package.extras]
@@ -1674,6 +1675,21 @@ files = [
 six = ">=1.5"
 
 [[package]]
+name = "python-dotenv"
+version = "1.0.1"
+description = "Read key-value pairs from a .env file and set them as environment variables"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "python-dotenv-1.0.1.tar.gz", hash = "sha256:e324ee90a023d808f1959c46bcbc04446a10ced277783dc6ee09987c37ec10ca"},
+    {file = "python_dotenv-1.0.1-py3-none-any.whl", hash = "sha256:f7b63ef50f1b690dddf550d03497b66d609393b40b564ed0d674909a68ebf16a"},
+]
+
+[package.extras]
+cli = ["click (>=5.0)"]
+
+[[package]]
 name = "pytz"
 version = "2024.2"
 description = "World timezone definitions, modern and historical"
@@ -2133,4 +2149,4 @@ propcache = ">=0.2.0"
 [metadata]
 lock-version = "2.1"
 python-versions = "<4.0,>=3.12"
-content-hash = "57c489aa41e87677e698b424bc0540a94295da7377ef7bc4f21eaa9c63301456"
+content-hash = "95896fddd0d57aaca5a8fc09398f8f192aee5b889cd32c8482c933661501ac4d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
 license = {text = "MIT"}
 requires-python = "<4.0,>=3.12"
 dependencies = [
-    "flask<4.0.0,>=3.0.3",
+    "flask[dotenv] (>=3.1.0,<4.0.0)",
     "flask-sqlalchemy<4.0.0,>=3.1.1",
     "sqlalchemy[postgresql]<3.0.0,>=2.0.30",
     "requests<3.0.0,>=2.31.0",


### PR DESCRIPTION
When working locally, this will now make sure `python-dotenv` is included in the dependencies and will load the `.env` config file.